### PR TITLE
Opens Dashboard in new tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,6 @@
+chrome.runtime.onInstalled.addListener(function() {
+  chrome.browserAction.onClicked.addListener(function(activeTab){
+    var newURL = "https://dashboard.e-gineering.com/";
+    chrome.tabs.create({ url: newURL });
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,13 @@
     "name": "E-gineering Dashboard Styler",
     "version": "0.0.1",
     "description": "Custom styles for the Dashboard",
+    "background": {
+        "scripts": ["background.js"],
+        "persistent": false
+    },
+    "browser_action": {
+        "default_icon": "images/EG-Gear16.png"
+    },
     "icons": {
         "16": "images/EG-Gear16.png",
         "32": "images/EG-Gear32.png",


### PR DESCRIPTION
Opens Dashboard in new tab when pressing the extension button.  Not sure if this is something that would be needed or useful.  It creates a structure that allows later to replace the code to open a new tab with a popup.  We could use this to possibly create a toggle for a light/dark mode.